### PR TITLE
eX standards compliance

### DIFF
--- a/cdi-commons/pom.xml
+++ b/cdi-commons/pom.xml
@@ -1,44 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-      <artifactId>sample-cdi-portlet</artifactId>
-      <groupId>org.exoplatform.addons.sample-cdi</groupId>
-      <version>1.0.x-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>sample-cdi-portlet-commons</artifactId>
-    <packaging>jar</packaging>
-    <name>CDI Commons</name>
-
-    <dependencies>        
-        <!-- CDI dependencies -->
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>javax.portlet</groupId>
-            <artifactId>portlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.gatein.api</groupId>
-            <artifactId>gatein-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <finalName>${project.artifactId}</finalName>        
-    </build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>sample-cdi-portlet</artifactId>
+    <groupId>org.exoplatform.addons.sample-cdi</groupId>
+    <version>1.0.x-SNAPSHOT</version>
+  </parent>
+  <artifactId>sample-cdi-portlet-commons</artifactId>
+  <packaging>jar</packaging>
+  <name>CDI Commons</name>
+  <dependencies>
+    <!-- CDI dependencies -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.portlet</groupId>
+      <artifactId>portlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.gatein.api</groupId>
+      <artifactId>gatein-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
 </project>

--- a/cdi-commons/pom.xml
+++ b/cdi-commons/pom.xml
@@ -3,12 +3,12 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <artifactId>sample-cdi-portlet-parent</artifactId>
-      <groupId>org.exoplatform.addons.portlets</groupId>
+      <artifactId>sample-cdi-portlet</artifactId>
+      <groupId>org.exoplatform.addons.sample-cdi</groupId>
       <version>1.0.x-SNAPSHOT</version>
     </parent>
 
-    <artifactId>cdi-commons</artifactId>
+    <artifactId>sample-cdi-portlet-commons</artifactId>
     <packaging>jar</packaging>
     <name>CDI Commons</name>
 

--- a/cdi-jboss/pom.xml
+++ b/cdi-jboss/pom.xml
@@ -3,20 +3,20 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <artifactId>sample-cdi-portlet-parent</artifactId>
-      <groupId>org.exoplatform.addons.portlets</groupId>
+      <artifactId>sample-cdi-portlet</artifactId>
+      <groupId>org.exoplatform.addons.sample-cdi</groupId>
       <version>1.0.x-SNAPSHOT</version>
     </parent>
 
-    <artifactId>cdi-jboss</artifactId>
+    <artifactId>sample-cdi-portlet-jboss</artifactId>
     <packaging>war</packaging>
     <name>CDI Portlet with JSF for JBoss</name>
     <description>This project demonstrates how to use CDI and JSF in portlets.</description>
 
     <dependencies>
         <dependency>
-            <groupId>org.exoplatform.addons.portlets</groupId>
-            <artifactId>cdi-commons</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sample-cdi-portlet-commons</artifactId>
         </dependency>       
     </dependencies>
 

--- a/cdi-jboss/pom.xml
+++ b/cdi-jboss/pom.xml
@@ -1,28 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-      <artifactId>sample-cdi-portlet</artifactId>
-      <groupId>org.exoplatform.addons.sample-cdi</groupId>
-      <version>1.0.x-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>sample-cdi-portlet-jboss</artifactId>
-    <packaging>war</packaging>
-    <name>CDI Portlet with JSF for JBoss</name>
-    <description>This project demonstrates how to use CDI and JSF in portlets.</description>
-
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>sample-cdi-portlet-commons</artifactId>
-        </dependency>       
-    </dependencies>
-
-    <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-        </plugins>
-    </build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>sample-cdi-portlet</artifactId>
+    <groupId>org.exoplatform.addons.sample-cdi</groupId>
+    <version>1.0.x-SNAPSHOT</version>
+  </parent>
+  <artifactId>sample-cdi-portlet-jboss</artifactId>
+  <packaging>war</packaging>
+  <name>CDI Portlet with JSF for JBoss</name>
+  <description>This project demonstrates how to use CDI and JSF in portlets.</description>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sample-cdi-portlet-commons</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins />
+  </build>
 </project>

--- a/cdi-tomcat/pom.xml
+++ b/cdi-tomcat/pom.xml
@@ -1,28 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-      <artifactId>sample-cdi-portlet</artifactId>
-      <groupId>org.exoplatform.addons.sample-cdi</groupId>
-      <version>1.0.x-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>sample-cdi-portlet-tomcat</artifactId>
-    <packaging>war</packaging>
-    <name>CDI Portlet with JSF for Tomcat</name>
-    <description>This project demonstrates how to use CDI and JSF in portlets.</description>
-
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>sample-cdi-portlet-commons</artifactId>
-        </dependency>       
-    </dependencies>
-
-    <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>        
-        </plugins>
-    </build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>sample-cdi-portlet</artifactId>
+    <groupId>org.exoplatform.addons.sample-cdi</groupId>
+    <version>1.0.x-SNAPSHOT</version>
+  </parent>
+  <artifactId>sample-cdi-portlet-tomcat</artifactId>
+  <packaging>war</packaging>
+  <name>CDI Portlet with JSF for Tomcat</name>
+  <description>This project demonstrates how to use CDI and JSF in portlets.</description>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sample-cdi-portlet-commons</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins />
+  </build>
 </project>

--- a/cdi-tomcat/pom.xml
+++ b/cdi-tomcat/pom.xml
@@ -3,20 +3,20 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <artifactId>sample-cdi-portlet-parent</artifactId>
-      <groupId>org.exoplatform.addons.portlets</groupId>
+      <artifactId>sample-cdi-portlet</artifactId>
+      <groupId>org.exoplatform.addons.sample-cdi</groupId>
       <version>1.0.x-SNAPSHOT</version>
     </parent>
 
-    <artifactId>cdi-tomcat</artifactId>
+    <artifactId>sample-cdi-portlet-tomcat</artifactId>
     <packaging>war</packaging>
     <name>CDI Portlet with JSF for Tomcat</name>
     <description>This project demonstrates how to use CDI and JSF in portlets.</description>
 
     <dependencies>
         <dependency>
-            <groupId>org.exoplatform.addons.portlets</groupId>
-            <artifactId>cdi-commons</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sample-cdi-portlet-commons</artifactId>
         </dependency>       
     </dependencies>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -15,7 +15,6 @@
       <groupId>org.jboss.weld.servlet</groupId>
       <artifactId>weld-servlet</artifactId>
     </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>sample-cdi-portlet-tomcat</artifactId>
@@ -56,7 +55,7 @@
             <configuration>
               <appendAssemblyId>true</appendAssemblyId>
               <descriptors>
-	 	<descriptor>src/main/assemblies/sample-cdi-tomcat.xml</descriptor>
+                <descriptor>src/main/assemblies/sample-cdi-tomcat.xml</descriptor>
               </descriptors>
             </configuration>
           </execution>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>sample-cdi-portlet-parent</artifactId>
-    <groupId>org.exoplatform.addons.portlets</groupId>
+    <artifactId>sample-cdi-portlet</artifactId>
+    <groupId>org.exoplatform.addons.sample-cdi</groupId>
     <version>1.0.x-SNAPSHOT</version>
   </parent>
   <artifactId>sample-cdi-portlet-packaging</artifactId>
@@ -17,18 +17,18 @@
     </dependency>
 
     <dependency>
-      <groupId>org.exoplatform.addons.portlets</groupId>
-      <artifactId>cdi-tomcat</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sample-cdi-portlet-tomcat</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.addons.portlets</groupId>
-      <artifactId>cdi-jboss</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sample-cdi-portlet-jboss</artifactId>
       <type>war</type>
     </dependency>
   </dependencies>
   <build>
-    <finalName>sample-cdi-portlet</finalName>
+    <finalName>sample-cdi-portlet-packaging</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/packaging/src/main/assemblies/sample-cdi-jboss.xml
+++ b/packaging/src/main/assemblies/sample-cdi-jboss.xml
@@ -32,7 +32,7 @@
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>${project.groupId}:cdi-jboss:war</include>
+        <include>${project.groupId}:sample-cdi-portlet-jboss:war</include>
       </includes>
       <outputFileNameMapping>cdi-jboss.war</outputFileNameMapping>
     </dependencySet>

--- a/packaging/src/main/assemblies/sample-cdi-tomcat.xml
+++ b/packaging/src/main/assemblies/sample-cdi-tomcat.xml
@@ -39,7 +39,7 @@
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>${project.groupId}:cdi-tomcat:war</include>
+        <include>${project.groupId}:sample-cdi-portlet-tomcat:war</include>
       </includes>
       <outputFileNameMapping>cdi-tomcat.war</outputFileNameMapping>
     </dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- Import versions of external dependencies to use -->
-      <dependency>
-        <groupId>org.exoplatform</groupId>
-        <artifactId>maven-depmgt-pom</artifactId>
-        <version>${org.exoplatform.depmgt.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- Import versions from platform project -->
       <dependency>
         <groupId>org.exoplatform.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,37 +28,33 @@
     <groupId>org.exoplatform.addons</groupId>
     <version>4</version>
   </parent>
-
   <groupId>org.exoplatform.addons.sample-cdi</groupId>
   <artifactId>sample-cdi-portlet</artifactId>
   <version>1.0.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Sample CDI Portlet Parent</name>
   <description>Sample CDI Portlet Parent</description>
-  <scm>
-    <connection>scm:git:git://github.com/exo-addons/sample-cdi-portlet.git</connection>
-    <developerConnection>scm:git:git@github.com:exo-addons/sample-cdi-portlet.git</developerConnection>
-    <url>https://github.com/exo-addons/sample-cdi-portlet</url>
-    <tag>HEAD</tag>
-  </scm>  
   <modules>
     <module>cdi-commons</module>
     <module>cdi-jboss</module>
     <module>cdi-tomcat</module>
     <module>packaging</module>
   </modules>
-
+  <scm>
+    <connection>scm:git:git://github.com/exo-addons/sample-cdi-portlet.git</connection>
+    <developerConnection>scm:git:git@github.com:exo-addons/sample-cdi-portlet.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/exo-addons/sample-cdi-portlet</url>
+  </scm>
   <properties>
     <maven.compiler.target>1.6</maven.compiler.target>
     <maven.compiler.source>1.6</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <org.exoplatform.depmgt.version>11-SNAPSHOT</org.exoplatform.depmgt.version>
     <platform.version>4.3.x-SNAPSHOT</platform.version>
     <version.gatein>4.3.x-PLF-SNAPSHOT</version.gatein>
     <version.weld-servlet>1.1.8.Final</version.weld-servlet>
   </properties>
-
   <dependencyManagement>
     <dependencies>
       <!-- Import versions of external dependencies to use -->
@@ -83,14 +79,12 @@
         <version>${version.gatein}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>      
-
+      </dependency>
       <dependency>
         <groupId>org.jboss.weld.servlet</groupId>
-	<artifactId>weld-servlet</artifactId>
-	<version>${version.weld-servlet}</version>
+        <artifactId>weld-servlet</artifactId>
+        <version>${version.weld-servlet}</version>
       </dependency>
-
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>sample-cdi-portlet-commons</artifactId>
@@ -100,18 +94,16 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>sample-cdi-portlet-jboss</artifactId>
         <version>${project.version}</version>
-	<type>war</type>
+        <type>war</type>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>sample-cdi-portlet-tomcat</artifactId>
         <version>${project.version}</version>
-	<type>war</type>
+        <type>war</type>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
-
   <profiles>
     <profile>
       <id>project-repositories</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <version>4</version>
   </parent>
 
-  <groupId>org.exoplatform.addons.portlets</groupId>
-  <artifactId>sample-cdi-portlet-parent</artifactId>
+  <groupId>org.exoplatform.addons.sample-cdi</groupId>
+  <artifactId>sample-cdi-portlet</artifactId>
   <version>1.0.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Sample CDI Portlet Parent</name>
@@ -92,19 +92,19 @@
       </dependency>
 
       <dependency>
-        <groupId>org.exoplatform.addons.portlets</groupId>
-        <artifactId>cdi-commons</artifactId>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>sample-cdi-portlet-commons</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.addons.portlets</groupId>
-        <artifactId>cdi-jboss</artifactId>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>sample-cdi-portlet-jboss</artifactId>
         <version>${project.version}</version>
 	<type>war</type>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.addons.portlets</groupId>
-        <artifactId>cdi-tomcat</artifactId>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>sample-cdi-portlet-tomcat</artifactId>
         <version>${project.version}</version>
 	<type>war</type>
       </dependency>


### PR DESCRIPTION
- I changed the groupId and groupIds to be compliant with eXo standards and having a better organization in nexus.
- I reformat your POMs with available eXo profiles (you should do it by yourself by launching `mvn -Pformat-pom` befor committing)
- I remove the dependency import of maven-depmgt-pom because it is already included in the dependency import of org.exoplatform.platform: platform

Please validate and merge
